### PR TITLE
Prevent Drupal from converting double underscores in class names

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -4,3 +4,4 @@ projects[drupal][version] = 7.36
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-7.x-allow_profile_change_sys_req-1772316-28.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-1470656-26.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/core-111702-99-use_replyto.patch
+projects[drupal][patch][] = https://www.drupal.org/files/drupal-remove_double_underscore_from_css_filter-2009584-16.patch


### PR DESCRIPTION
When a site builder tries to use a class in Views UI (or another contrib module) that contains a double underscore, core will convert it into a double dash. Bad core!

Steps to test:
- Go to https://agov_pr527.agov.com.au/admin/structure/views/view/events/edit
- Click the Format: Settings link
- Add a Row class called `double__underscore`
- Apply to all displays and save the View
- Visit https://agov_pr527.agov.com.au/news-media/events and inspect the HTML source

You should see:
![screen shot 2015-06-02 at 11 10 37](https://cloud.githubusercontent.com/assets/33429/7927832/091eda5a-0918-11e5-8655-2d799151b4cc.png)
