### PR TITLE
32420 footer divider

### DIFF
--- a/themes/agov/agov_whitlam/panels-layouts/home/agov-layouts-home.tpl.php
+++ b/themes/agov/agov_whitlam/panels-layouts/home/agov-layouts-home.tpl.php
@@ -20,13 +20,13 @@
     </div>
   <?php endif; ?>
 
-  <?php if($content['main']): ?>
+  <?php if ($content['main'] || $content['right-sidebar']): ?>
     <div class="layout-3col__left-content">
       <?php print $content['main'];?>
     </div>
   <?php endif; ?>
 
-  <?php if($content['right-sidebar']): ?>
+  <?php if ($content['right-sidebar']): ?>
     <div class="layout-3col__right-sidebar">
       <?php print $content['right-sidebar'];?>
     </div>
@@ -37,25 +37,26 @@
       <hr>
       <div class="layout-3col">
 
-    <?php if ($content['footer-1']): ?>
-      <div class="layout-3col__col-1">
-        <?php print $content['footer-1'];?>
-      </div>
-    <?php endif; ?>
+        <?php if ($content['footer-1']): ?>
+          <div class="layout-3col__col-1">
+            <?php print $content['footer-1'];?>
+          </div>
+        <?php endif; ?>
 
-    <?php if ($content['footer-2']) : ?>
-      <div class="layout-3col__col-2">
-        <?php print $content['footer-2'];?>
-      </div>
-    <?php endif; ?>
+        <?php if ($content['footer-2']) : ?>
+          <div class="layout-3col__col-2">
+            <?php print $content['footer-2'];?>
+          </div>
+        <?php endif; ?>
 
-    <?php if ($content['footer-3']): ?>
-      <div class="layout-3col__col-3">
-        <?php print $content['footer-3'];?>
-      </div>
-    <?php endif; ?>
+        <?php if ($content['footer-3']): ?>
+          <div class="layout-3col__col-3">
+            <?php print $content['footer-3'];?>
+          </div>
+        <?php endif; ?>
 
-    </div></div>
+      </div>
+    </div>
   <?php endif; ?>
 
 </div>

--- a/themes/agov/agov_whitlam/sass/_variables.scss
+++ b/themes/agov/agov_whitlam/sass/_variables.scss
@@ -299,3 +299,11 @@ $nav-height: 2 * $base-line-height;
 // Drupal 8's standard [dir='rtl'] selector for RTL langauge support. You can
 // turn off all RTL CSS by setting the following variable to false.
 $include-rtl: false;
+
+//
+// Zen grids
+//
+
+// These are needed for all breakpoints on all layouts.
+$zen-auto-include-grid-item-base: false;
+$zen-box-sizing: universal-border-box;

--- a/themes/agov/agov_whitlam/sass/_variables.scss
+++ b/themes/agov/agov_whitlam/sass/_variables.scss
@@ -307,3 +307,7 @@ $include-rtl: false;
 // These are needed for all breakpoints on all layouts.
 $zen-auto-include-grid-item-base: false;
 $zen-box-sizing: universal-border-box;
+
+// The gutters in the layouts are larger on mobile.
+$zen-gutters--small: 40px;
+$zen-gutters--medium: 25px;

--- a/themes/agov/agov_whitlam/sass/components/footer-bottom/_footer-bottom.scss
+++ b/themes/agov/agov_whitlam/sass/components/footer-bottom/_footer-bottom.scss
@@ -14,18 +14,14 @@
   color: color(text-bg);
 
   &__left {
-    @include zen-apply-gutter-padding($gutters: 40px);
-
     @include respond-to(medium) {
-      @include zen-apply-gutter-padding($gutters: 25px);
       float: left;
     }
   }
 
   &__right {
-    @extend %footer-bottom__left;
-
     @include respond-to(medium) {
+      margin-left: 25px;
       float: right;
     }
   }

--- a/themes/agov/agov_whitlam/sass/components/footer-top/_footer-top.scss
+++ b/themes/agov/agov_whitlam/sass/components/footer-top/_footer-top.scss
@@ -1,3 +1,7 @@
+// Dependencies.
+@import 'layouts/layout-3col/layout-3col';
+@import 'components/unstyled-list/unstyled-list';
+
 // Footer Top
 //
 // The footer top region of page
@@ -13,4 +17,32 @@
   padding-top: 1px;
   padding-bottom: 25px;
 
+  // @TODO: Fix this bug in Chroma.
+  // scss-lint:disable ColorKeyword, ColorVariable
+  &__menu {
+    border-top: 2px solid color(white);
+    margin-top: 25px;
+
+    &:first-child {
+      border-top: 0;
+      margin-top: 0;
+    }
+
+    > ul {
+      @extend %layout-3col;
+      @extend %unstyled-list;
+
+      > li {
+        @extend %layout-3col__col-x;
+      }
+    }
+  }
+}
+
+//
+// Drupal selectors.
+//
+
+.footer-top .block {
+  @extend %footer-top__menu;
 }

--- a/themes/agov/agov_whitlam/sass/components/footer-top/_footer-top.scss
+++ b/themes/agov/agov_whitlam/sass/components/footer-top/_footer-top.scss
@@ -8,16 +8,9 @@
 
 .footer-top,
 %footer-top {
-  @include zen-apply-gutter-padding($gutters: 40px);
+  margin-top: 25px;
+  background-color: color(white-smoke);
+  padding-top: 1px;
+  padding-bottom: 25px;
 
-  @include respond-to(medium) {
-    @include zen-apply-gutter-padding($gutters: 25px);
-  }
-
-  &__wrapper {
-    margin-top: 25px;
-    background-color: color(white-smoke);
-    padding-top: 1px;
-    padding-bottom: 25px;
-  }
 }

--- a/themes/agov/agov_whitlam/sass/components/footer-top/footer-top.hbs
+++ b/themes/agov/agov_whitlam/sass/components/footer-top/footer-top.hbs
@@ -1,12 +1,14 @@
 <div class="footer-top {{modifier_class}}">
   <div class="layout-center">
-    <h2>Footer Sub Menu</h2>
-    <ul>
-      <li><a href="#">Disclaimer</a></li>
-      <li><a href="#">Privacy</a></li>
-      <li><a href="#">Accessibility Notice</a></li>
-      <li><a href="#">Feedback</a></li>
-      <li><a href="#">Sitemap and Feeds</a></li>
-    </ul>
+    <div class="footer-top__menu">
+      <h2>Footer Sub Menu</h2>
+      <ul>
+        <li><a href="#">Disclaimer</a></li>
+        <li><a href="#">Privacy</a></li>
+        <li><a href="#">Accessibility Notice</a></li>
+        <li><a href="#">Feedback</a></li>
+        <li><a href="#">Sitemap and Feeds</a></li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/themes/agov/agov_whitlam/sass/components/footer-top/footer-top.hbs
+++ b/themes/agov/agov_whitlam/sass/components/footer-top/footer-top.hbs
@@ -1,5 +1,5 @@
-<div class="footer-top__wrapper {{modifier_class}}">
-  <div class="footer-top layout-center">
+<div class="footer-top {{modifier_class}}">
+  <div class="layout-center">
     <h2>Footer Sub Menu</h2>
     <ul>
       <li><a href="#">Disclaimer</a></li>

--- a/themes/agov/agov_whitlam/sass/components/unstyled-list/_unstyled-list.scss
+++ b/themes/agov/agov_whitlam/sass/components/unstyled-list/_unstyled-list.scss
@@ -10,6 +10,7 @@
 %unstyled-list {
   margin-top: 0;
   margin-bottom: 0;
+  padding: 0;
   list-style-type: none;
   list-style-image: none;
   text-indent: 0;
@@ -20,20 +21,5 @@
     margin-top: 0;
     margin-bottom: 0;
     padding-left: 0;
-  }
-}
-
-//
-// Drupal selectors.
-//
-
-// scss-lint:disable SelectorDepth
-
-.footer-top {
-  .block-menu,
-  .menu-block-wrapper {
-    > ul {
-      @extend %unstyled-list;
-    }
   }
 }

--- a/themes/agov/agov_whitlam/sass/layouts/layout-3col/_layout-3col.scss
+++ b/themes/agov/agov_whitlam/sass/layouts/layout-3col/_layout-3col.scss
@@ -46,7 +46,7 @@
 // Style guide: layouts.layout-3column
 
 $zen-columns: 1;
-$zen-gutters: 40px;
+$zen-gutters: $zen-gutters--small;
 
 .layout-3col,
 %layout-3col {
@@ -70,7 +70,7 @@ $zen-gutters: 40px;
   }
 
   $zen-columns: 2 !global;
-  $zen-gutters: 25px !global;
+  $zen-gutters: $zen-gutters--medium !global;
 
   @include respond-to(medium) {
     // Since our container's context is "flow" and we changed the gutter size,

--- a/themes/agov/agov_whitlam/sass/layouts/layout-3col/_layout-3col.scss
+++ b/themes/agov/agov_whitlam/sass/layouts/layout-3col/_layout-3col.scss
@@ -159,22 +159,3 @@ $zen-gutters: $zen-gutters--small;
     @include zen-grid-container($context: grid-item);
   }
 }
-
-//
-// Drupal selectors.
-//
-
-// scss-lint:disable SelectorDepth
-
-.footer-top {
-  .block-menu,
-  .menu-block-wrapper {
-    > ul {
-      @extend %layout-3col;
-
-      > li {
-        @extend %layout-3col__col-x;
-      }
-    }
-  }
-}

--- a/themes/agov/agov_whitlam/sass/layouts/layout-3col/_layout-3col.scss
+++ b/themes/agov/agov_whitlam/sass/layouts/layout-3col/_layout-3col.scss
@@ -45,14 +45,14 @@
 //
 // Style guide: layouts.layout-3column
 
+$zen-columns: 1;
+$zen-gutters: 40px;
+
 .layout-3col,
 %layout-3col {
+  // We set the context to flow, so that this container can be used in most
+  // places in the HTML
   @include zen-grid-container($context: flow);
-
-  $zen-columns: 1 !global;
-  $zen-gutters: 40px !global;
-  $zen-auto-include-grid-item-base: false !global;
-  $zen-box-sizing: universal-border-box !global;
 
   &__full,
   &__left-content,
@@ -83,8 +83,8 @@
     &__left-sidebar,
     &__right-sidebar {
       @include zen-grid-item(2, 1);
-      // Since we changed the gutter size, we need to re-apply the padding to
-      // every grid item.
+      // Since we changed the gutter size for this media query, we need to
+      // re-apply the padding to every grid item.
       @include zen-apply-gutter-padding();
     }
 

--- a/themes/agov/agov_whitlam/sass/layouts/layout-center/_layout-center.scss
+++ b/themes/agov/agov_whitlam/sass/layouts/layout-center/_layout-center.scss
@@ -8,6 +8,7 @@
 
 .layout-center,
 %layout-center {
-  max-width: 1165px;
+  // The max content width is 1140px (the container width minus the gutters.)
+  max-width: 1140px + $zen-gutters--medium;
   margin: 0 auto;
 }

--- a/themes/agov/agov_whitlam/sass/layouts/layout-center/_layout-center.scss
+++ b/themes/agov/agov_whitlam/sass/layouts/layout-center/_layout-center.scss
@@ -1,6 +1,24 @@
+// Dependencies.
+// Allow layout-center's margin/padding to override layout-3col.
+@import 'layouts/layout-3col/layout-3col';
+
 // Layout Center
 //
-// Centered Layout
+// All other layouts should be nested inside this centered layout to ensure that
+// content does not get too wide on very large screens.
+//
+// Applying a `.layout-*` class to the same HTML element as `.layout-center`
+// would cause that element's grid to mis-align with the rest of the grid on the
+// page, but this component will automatically detect the other `.layout-*`
+// class and automatically use the `.layout-center--has-unnested-child` variant
+// instead.
+//
+// .layout-center--has-unnested-child - If `.layout-center` is applied to the
+//                                      same div as another .layout-* class,
+//                                      then this variant should be used to fix
+//                                      the grid alignment. Note: Each time a
+//                                      new .layout-* component is created, this
+//                                      component will need to be modified.
 //
 // Markup: layout-center.hbs
 //
@@ -8,7 +26,31 @@
 
 .layout-center,
 %layout-center {
+  @include zen-apply-gutter-padding($zen-gutters--small);
   // The max content width is 1140px (the container width minus the gutters.)
   max-width: 1140px + $zen-gutters--medium;
   margin: 0 auto;
+
+  @include respond-to(medium) {
+    @include zen-apply-gutter-padding($zen-gutters--medium);
+  }
+
+  // Since .layout-center has overridden the negative margin on another
+  // .layout-* container, we don't need the gutter on
+  &--has-unnested-child {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+//
+// Fugly selectors.
+//
+
+.layout-center {
+  // Ensure the .layout-center--no-padding variant is automatically used by
+  // adding all other .layout-* classes here.
+  &.layout-3col {
+    @extend %layout-center--has-unnested-child;
+  }
 }

--- a/themes/agov/agov_whitlam/templates/menu-block-wrapper.tpl.php
+++ b/themes/agov/agov_whitlam/templates/menu-block-wrapper.tpl.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file
+ * Default theme implementation to wrap menu blocks.
+ *
+ * Available variables:
+ * - $content: The renderable array containing the menu.
+ * - $classes: A string containing the CSS classes for the DIV tag. Includes:
+ *   menu-block-DELTA, menu-name-NAME, parent-mlid-MLID, and menu-level-LEVEL.
+ * - $classes_array: An array containing each of the CSS classes.
+ *
+ * The following variables are provided for contextual information.
+ * - $delta: (string) The menu_block's block delta.
+ * - $config: An array of the block's configuration settings. Includes
+ *   menu_name, parent_mlid, title_link, admin_title, level, follow, depth,
+ *   expanded, and sort.
+ *
+ * @see template_preprocess_menu_block_wrapper()
+ */
+?>
+<?php print render($content); ?>

--- a/themes/agov/agov_whitlam/templates/region--footer.tpl.php
+++ b/themes/agov/agov_whitlam/templates/region--footer.tpl.php
@@ -8,8 +8,8 @@
  */
 ?>
 <?php if ($content): ?>
-  <div class="footer-top__wrapper <?php print $classes; ?>">
-    <div class="footer-top layout-center">
+  <div class="footer-top <?php print $classes; ?>">
+    <div class="layout-center">
       <?php print $content; ?>
     </div>
   </div>


### PR DESCRIPTION
This PR is to add the footer divider between the blocks in the footer-top region.

It turns out there were lots of bugs that needed fixing before the divider would line up with the content.

Included in this PR:
- Fix nested grid/mobile padding bug. (parts of layout weren't aligning properly on mobile)

  Before: ![screen shot 2015-06-18 at 11 27 05](https://cloud.githubusercontent.com/assets/33429/8223627/1d402196-15ad-11e5-9c52-e835d776653f.png) After: ![screen shot 2015-06-18 at 11 27 39](https://cloud.githubusercontent.com/assets/33429/8223643/6357efd8-15ad-11e5-848f-d3aee3279e5a.png)

  The "before" alignment was all over the place. The "after" is much better, but still needs some tweaking in the header area; however the navbar/search bits need some HTML refactoring because it relies on JavaScript for layout right now, so that work will be in a follow-up PR.

- Add variables to better document zen gutter changes. (random 25px and 40px values in layout files were confusing.)
- Add padding to `layout-center`. (which coincidently fixes the navbar not aligning with the rest of the layout but is required by the footer divider change.)

  Before: ![screen shot 2015-06-18 at 11 21 29](https://cloud.githubusercontent.com/assets/33429/8223575/3f97f292-15ac-11e5-8bcc-a2a58d3a4951.png) After: ![screen shot 2015-06-18 at 11 21 36](https://cloud.githubusercontent.com/assets/33429/8223581/486f4262-15ac-11e5-8a0d-90ff28f1ef0e.png)
- Fix home layout when no main content with right sidebar. (because the block of "latest updates" disappeared while I was testing this locally and totally broke the layout.)
- Add horizontal bar between footer blocks.