### PR TITLE
The other install profile descriptions all end in a period, aGovs should too.

### DIFF
--- a/agov.info
+++ b/agov.info
@@ -1,6 +1,6 @@
 name = aGov
 project = agov
-description = A distribution for government and the public sector in Australia
+description = A distribution for government and the public sector in Australia.
 core = 7.x
 
 php = 5.3

--- a/agov.info
+++ b/agov.info
@@ -2,7 +2,7 @@ name = aGov
 project = agov
 description = A distribution for government and the public sector in Australia.
 core = 7.x
-
+exclusive = TRUE
 php = 5.3
 
 ; System Requirements.


### PR DESCRIPTION
aGovs description doesn't end with a full stop, like all the other kids. Can merge back to 2.x and 1.x too.

![screen shot 2015-07-15 at 8 48 58 am](https://cloud.githubusercontent.com/assets/148719/8686990/e0a15db8-2ace-11e5-9ec4-8f89b3798c9b.png)
