### PR TITLE
[#33093] Fixed colour contrast for active breadcrumb item

### DIFF
--- a/themes/agov/agov_whitlam/sass/_variables.scss
+++ b/themes/agov/agov_whitlam/sass/_variables.scss
@@ -248,7 +248,7 @@ $chroma: add-colors('functional', (
   form-element-bg:            'body-bg',
   form-element-bg-hover:      'white-smoke',
 
-  breadcrumb-color:       'grey-medium',
+  breadcrumb-color:       'grey-dark',
 
   comment-date:           'grey-dark',
   comment-icon:           'grey-dark',


### PR DESCRIPTION
Active breadcrumb should no longer fail colour contrast
![](https://dl.dropbox.com/s/2y7buact8v7udsy/Screenshot%202015-07-16%2011.57.42.png?dl=0)