### PR TITLE
32863 fix padding margins

### DIFF
--- a/modules/features/agov_front/agov_front.pages_default.inc
+++ b/modules/features/agov_front/agov_front.pages_default.inc
@@ -192,7 +192,7 @@ function agov_front_default_page_manager_pages() {
     );
     $pane->css = array(
       'css_id' => '',
-      'css_class' => 'divider',
+      'css_class' => 'divider divider--reduced-bottom-spacing',
     );
     $pane->extras = array();
     $pane->position = 1;

--- a/themes/agov/agov_whitlam/sass/base/headings/_headings.scss
+++ b/themes/agov/agov_whitlam/sass/base/headings/_headings.scss
@@ -18,6 +18,10 @@
   @include leader(1);
   @include trailer(1);
   font-weight: bold;
+
+  &--twitter {
+    @include trailer(.3);
+  }
 }
 
 // Address variable `h1` font-size and margin within `section` and `article`
@@ -56,4 +60,10 @@ h6,
 %h6 {
   @extend %heading;
   @include adjust-font-size-to(.67 * $base-font-size);
+}
+
+
+// Fugly selectors.
+.pane-twitter-block-1 h2 {
+  @extend %heading--twitter;
 }

--- a/themes/agov/agov_whitlam/sass/components/divider/_divider.scss
+++ b/themes/agov/agov_whitlam/sass/components/divider/_divider.scss
@@ -8,12 +8,16 @@
 
 .divider,
 %divider {
-  @include output-rhythm(margin, rhythm(1) 0);
+  @include output-rhythm(margin, rhythm(1.6) 0);
   border: 0;
   border-top: 10px solid color(border);
 
   // If used as a container, add a top margin to the first child.
   > :first-child {
-    @include output-rhythm(margin-top, rhythm(1));
+    @include output-rhythm(margin-top, rhythm(1.6));
+  }
+
+  &--reduced-bottom-spacing {
+    @include output-rhythm(margin-bottom, rhythm(.1));
   }
 }

--- a/themes/agov/agov_whitlam/sass/components/footer-top/_footer-top.scss
+++ b/themes/agov/agov_whitlam/sass/components/footer-top/_footer-top.scss
@@ -12,9 +12,9 @@
 
 .footer-top,
 %footer-top {
-  margin-top: 25px;
+  margin-top: 60px;
   background-color: color(white-smoke);
-  padding-top: 1px;
+  padding-top: 60px;
   padding-bottom: 25px;
 
   // @TODO: Fix this bug in Chroma.


### PR DESCRIPTION
Amended padding and margin spacing on frontpage:
Before:
![agov -before](https://cloud.githubusercontent.com/assets/915322/8743015/7da6c6c6-2cae-11e5-8286-0a3728729d10.png)

After:
![agov](https://cloud.githubusercontent.com/assets/915322/8742974/15b6c930-2cae-11e5-903c-f58c5ef6ad75.png)