### PR TITLE
[#33279 Increased placeholder text and made border white on hover

### DIFF
--- a/themes/agov/agov_whitlam/sass/components/search/_search.scss
+++ b/themes/agov/agov_whitlam/sass/components/search/_search.scss
@@ -62,7 +62,7 @@
     padding: 0;
     font-style: italic;
     font-weight: bold;
-    font-size:20px;
+    font-size: 18px;
 
     @include input-placeholder() {
       @include opacity(1);

--- a/themes/agov/agov_whitlam/sass/components/search/_search.scss
+++ b/themes/agov/agov_whitlam/sass/components/search/_search.scss
@@ -12,14 +12,12 @@
   color: color(search-color);
   background: color(search-bg);
 
-
   &--light {
     @include respond-to('medium') {
       color: color(search-color-light);
       background: transparent;
     }
   }
-
 
   &__wrapper {
     width: 100%;
@@ -44,6 +42,11 @@
         border-bottom: 2px solid color(search-border);
         min-width: 363px;
         padding: 0 0 13px;
+
+        &:hover,
+        &:focus {
+          border-color: color(white);
+        }
       }
     }
   }
@@ -59,6 +62,7 @@
     padding: 0;
     font-style: italic;
     font-weight: bold;
+    font-size:20px;
 
     @include input-placeholder() {
       @include opacity(1);


### PR DESCRIPTION
Steps/what to test:
Check the search's placeholder has been changed to 18px and that border turn white on hover

![](https://dl.dropbox.com/s/hivjvcoymw4c74u/Screenshot%202015-07-17%2018.37.35.png?dl=0)

After font size fix

![](https://dl.dropbox.com/s/71nquksk706j00x/Screenshot%202015-07-20%2011.34.33.png?dl=0)