### PR TITLE
33426 fix styles fields

### DIFF
--- a/themes/agov/agov_whitlam/sass/components/field/_field.scss
+++ b/themes/agov/agov_whitlam/sass/components/field/_field.scss
@@ -1,0 +1,17 @@
+.field,
+%field {
+  @include output-rhythm(margin, rhythm(1) 0);
+
+  &--no-spacing {
+   margin: 0
+  }
+}
+
+//Fugly selectors.
+
+//Few fields should not have spacing.
+
+.field-type-text-with-summary,
+.teaser .field {
+  @extend %field--no-spacing;
+}

--- a/themes/agov/agov_whitlam/sass/components/tags/_tags.scss
+++ b/themes/agov/agov_whitlam/sass/components/tags/_tags.scss
@@ -1,0 +1,38 @@
+// Tags
+//
+// tags.
+//
+// Markup: tags.hbs
+//
+// Style guide: components.tags
+
+.tags,
+%tags {
+
+  &__items {
+    @extend %unstyled-list;
+    display: inline;
+  }
+
+  &__item {
+    padding-left: 3rem;
+
+    @include respond-to('medium') {
+      display: inline-block;
+      padding-left: 0;
+
+      &:after {
+        content: ', ';
+      }
+
+      &:last-child:after {
+        content: '';
+      }
+    }
+
+    &:first-child {
+      display: inline-block;
+      padding-left: 0;
+    }
+  }
+}

--- a/themes/agov/agov_whitlam/sass/components/tags/tags.hbs
+++ b/themes/agov/agov_whitlam/sass/components/tags/tags.hbs
@@ -1,0 +1,9 @@
+<div class="tags">
+  <label class="inline-sibling">Tags:</label>
+  <ul class="tags__items">
+    <li class="tags__item"><a href="#">ponderum</a></li>
+    <li class="tags__item"><a href="#">ipsum</a></li>
+    <li class="tags__item"><a href="#">enim lenis</a></li>
+    <li class="tags__item"><a href="#">secundum suscipere</a></li>
+  </ul>
+</div>

--- a/themes/agov/agov_whitlam/templates/field--field-tags.tpl.php
+++ b/themes/agov/agov_whitlam/templates/field--field-tags.tpl.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @file
+ * Returns the HTML for field.
+ */
+?>
+<div class="tags">
+  <?php if (!$label_hidden): ?>
+    <span class="tags__label"<?php print $title_attributes; ?>><strong><?php print $label ?></strong>:&nbsp;</span>
+  <?php endif; ?>
+  <ul class="tags__items"<?php print $content_attributes; ?>>
+    <?php foreach ($items as $delta => $item): ?>
+      <li class="tags__item <?php print $delta % 2 ? 'odd' : 'even'; ?>"<?php print $item_attributes[$delta]; ?>><?php print render($item); ?></li>
+    <?php endforeach; ?>
+  </ul>
+</div>


### PR DESCRIPTION
Steps/What to test:

1) Go to page that contain tags e.g/news-media/blog/blandit-tation-typicus.

Check tags look as follows:
  on desktop: ![](https://dl.dropbox.com/s/rhrmyu7ffahpaoj/Screenshot%202015-07-23%2010.30.52.png?dl=0)
 
 on mobile: ![](https://dl.dropbox.com/s/1iech9o6ky9jwse/Screenshot%202015-07-23%2010.31.09.png?dl=0)

2) Check fields on full mode view have spacing applied.

Best to test on an events page:

![](https://dl.dropbox.com/s/m5epfox6y76b4ye/Screenshot%202015-07-23%2010.45.03.png?dl=0)