### PR TITLE
Issue #2552333: Iconomist warnings

### DIFF
--- a/modules/custom/iconomist/iconomist.module
+++ b/modules/custom/iconomist/iconomist.module
@@ -310,9 +310,11 @@ function _iconomist_settings_submit($form, &$form_state) {
 
   $icons = &$form_state['values']['iconomist_icons'];
   $file_usages = array();
-  foreach ($icons as $icon) {
-    if (!empty($icon['usage_id'])) {
-      $file_usages[$icon['usage_id']] = $icon['fid'];
+  if (!empty($icons)) {
+    foreach ($icons as $icon) {
+      if (!empty($icon['usage_id'])) {
+        $file_usages[$icon['usage_id']] = $icon['fid'];
+      }
     }
   }
 
@@ -327,17 +329,19 @@ function _iconomist_settings_submit($form, &$form_state) {
 
   // Add new file usages.
   $added_usages = array();
-  foreach ($icons as &$icon) {
-    if (isset($icon['fid']) && empty($icon['usage_id'])) {
-      $file = file_load($icon['fid']);
-      if ($file) {
-        // Mark file as permanent.
-        $file->status = FILE_STATUS_PERMANENT;
-        file_save($file);
-        // Add file usage.
-        $icon['usage_id'] = _iconomist_get_usage_id();
-        $added_usages[$icon['usage_id']] = $file->fid;
-        file_usage_add($file, 'iconomist', 'theme', $icon['usage_id']);
+  if (!empty($icons)) {
+    foreach ($icons as &$icon) {
+      if (isset($icon['fid']) && empty($icon['usage_id'])) {
+        $file = file_load($icon['fid']);
+        if ($file) {
+          // Mark file as permanent.
+          $file->status = FILE_STATUS_PERMANENT;
+          file_save($file);
+          // Add file usage.
+          $icon['usage_id'] = _iconomist_get_usage_id();
+          $added_usages[$icon['usage_id']] = $file->fid;
+          file_usage_add($file, 'iconomist', 'theme', $icon['usage_id']);
+        }
       }
     }
   }


### PR DESCRIPTION
Wrap the loops with a !empty() to avoid warnings when no icons are configured.