### PR TITLE
Corrects the location of the styleguide symlink

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -166,6 +166,19 @@
   </target>
 
   <target name="styleguide:link" description="Link the style guide to make it publicly available.">
+    <!-- Create -->
+    <exec command="mkdir -p ${app.dir}/${app.profile.dir}/styleguide"
+          logoutput="true"
+          passthru="true"
+          checkreturn="true" />
+
+    <!-- Permissions -->
+    <exec command="chmod -R 775 ${app.dir}/${app.profile.dir}/styleguide"
+          logoutput="true"
+          passthru="true"
+          checkreturn="true" />
+
+    <!-- Symlink the app styleguide folder into the profiles styleguide folder. -->
     <symlink link="${app.dir}/styleguide" target="${app.dir}/${app.profile.dir}/styleguide" />
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -166,7 +166,7 @@
   </target>
 
   <target name="styleguide:link" description="Link the style guide to make it publicly available.">
-    <symlink link="${app.dir}/${app.profile.dir}/styleguide" target="${project.basedir}/styleguide" />
+    <symlink link="${app.dir}/styleguide" target="${app.dir}/${app.profile.dir}/styleguide" />
   </target>
 
   <target name="login" description="Generate a one-time login link">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,8 +18,8 @@ var options = {},
 options.rootPath = {
   project     : __dirname + '/',
   web         : __dirname + '/app/',
-  styleGuide  : __dirname + '/agov/styleguide/agov_base/',
-  theme       : __dirname + '/agov/themes/agov/agov_base/'
+  styleGuide  : __dirname + '/app/styleguide/agov_base/',
+  theme       : __dirname + '/app/profiles/agov/themes/agov/agov_base/'
 };
 
 // Define the paths in the Drupal theme by getting theme sub-directories from


### PR DESCRIPTION
The symlink for the styleguide was using the wrong location.

Keep in mind the styleguide for the base theme is accessed at:

http://agov.dev/styleguide/agov_base/

Steps to test:
* Remove any existing symlinks to the styleguide inside /app
* run phing styleguide:link
* run gulp
* ensure you can access the styleguide at the link above
* ensure the styles are showing!